### PR TITLE
Implement $windowId macro substitution

### DIFF
--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -174,7 +174,7 @@ namespace Bart {
         }
 
         export function isFilter(token: string): boolean {
-            return [ 'title', 'url', 'curr', '$' ].includes(token);
+            return [ 'title', 'url', 'curr', '$', 'windowId' ].includes(token);
         }
 
         export function isNegation(token: string): boolean {
@@ -466,7 +466,7 @@ namespace Bart {
                         return (tab: Tab, context: Context) => { return context.selectedTabIds.has(tab.id) };
                     default:
                         let stringFilter = this.arg.filter();
-                        return (tab: Tab, context: Context) => { return stringFilter(tab[this.type]) };
+                        return (tab: Tab, context: Context) => { return stringFilter(tab[this.type]+'') };
                 }
             }
 

--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -114,6 +114,10 @@ namespace Bart {
                     case TokenType.GroupModifier:
                         bartClass = "bart-group-modifier";
                         break;
+                    case TokenType.Macro:
+                        bartClass = "bart-macro";
+                        break;
+
                 }
 
                 let explodedValue = 
@@ -154,7 +158,8 @@ namespace Bart {
             Negation,
             Combinator,
             Command,
-            GroupModifier
+            GroupModifier,
+            Macro
         }
 
         export function isGroupModifier(token: string): boolean {
@@ -163,6 +168,10 @@ namespace Bart {
 
         export function isString(token: string): boolean {
             return token.startsWith('"') && token.endsWith('"');
+        }
+
+        export function isMacro(token: string): boolean {
+            return token.startsWith('$');
         }
 
         export function isFilter(token: string): boolean {
@@ -259,6 +268,8 @@ namespace Bart {
                     tokens.push(new Bart.Lexer.Token(token.start, token.end, Bart.Lexer.TokenType.Command, token.value));
                 } else if (Bart.Lexer.isGroupModifier(token.value)) {
                     tokens.push(new Bart.Lexer.Token(token.start, token.end, Bart.Lexer.TokenType.GroupModifier, token.value));
+                } else if (Bart.Lexer.isMacro(token.value)) {
+                    tokens.push(new Bart.Lexer.Token(token.start, token.end, Bart.Lexer.TokenType.Macro, token.value));
                 } else {
                     tokens.push(new Bart.Lexer.Token(token.start, token.end, Bart.Lexer.TokenType.Invalid, token.value));
                     //throw new Parser.ParseError();

--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -812,7 +812,7 @@ namespace Bart {
 
     export namespace Interpreter {
         export function interpret(input: string, tabs: Tab[], context: Context): Tab[] {
-            let ast = Parser.parse(input);
+            let ast = Parser.parse(input, context);
             console.log('==FILTER==');
             console.dir(ast, { depth:  null });
 

--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -117,7 +117,6 @@ namespace Bart {
                     case TokenType.Macro:
                         bartClass = "bart-macro";
                         break;
-
                 }
 
                 let explodedValue = 
@@ -751,7 +750,28 @@ namespace Bart {
         export function highlight(root: FilterCombinator) {
         }
 
-        export function parse(input: string): Command {
+        // TODO: Enum?
+        function substituteMacro(macro: string, context: Context): Lexer.Token {
+            let substitution = '';
+
+            if (macro == '$windowId') {
+                substitution = `"${context.currentWindowId}"`;
+            }
+
+            return new Lexer.Token(0, 0, Lexer.TokenType.StringArg, substitution);
+        }
+
+        export function substituteMacros(tokens: Bart.Lexer.Token[], context: Context): Bart.Lexer.Token[] {
+            for (let i = 0; i < tokens.length; i++) {
+                if (tokens[i].type == Bart.Lexer.TokenType.Macro) {
+                    tokens[i] = substituteMacro(tokens[i].value, context);
+                }
+            }
+
+            return tokens;
+        }
+
+        export function parse(input: string, context: Context): Command {
             let command: Command = Command.noop();
             let commandSymbol = command.type;
             let commandArgs = StringCombinator.emptyCombinator;
@@ -761,6 +781,8 @@ namespace Bart {
             }
 
             let tokens = Lexer.lex(input);
+            tokens = substituteMacros(tokens, context);
+            console.log('substituted tokens: ' + tokens.map(f => f.value).join(' '));
 
             // TODO: Move to separate method
             if (Bart.Lexer.isCommand(tokens[0].value)) {

--- a/src/components/TabList.svelte
+++ b/src/components/TabList.svelte
@@ -727,4 +727,8 @@
     :global(.bart-group-modifier) {
         color: blue;
     }
+
+    :global(.bart-macro) {
+        color: gray;
+    }
 </style>

--- a/src/components/TabList.svelte
+++ b/src/components/TabList.svelte
@@ -253,7 +253,7 @@
 
     function parseAST(input: string): Bart.Parser.Command {
         try {
-            return Bart.Parser.parse(input);
+            return Bart.Parser.parse(input, bartContext);
         } catch (error) {
             console.log('Failed to parse AST');
             return Bart.Parser.Command.noop();

--- a/tests/bart.test.ts
+++ b/tests/bart.test.ts
@@ -251,6 +251,7 @@ test('Test string negation', () => {
 });
 
 test('Test parse errors', () => {
+    let context = new Bart.TabContext();
     let parseErrors = [
         '"xyz"',    // no filter provided
         'ur',    // incomplete, TODO: Invalid filter
@@ -259,7 +260,7 @@ test('Test parse errors', () => {
     ];
 
     for (const error of parseErrors) {
-        expect(() => Bart.Parser.parse(error)).toThrow(Bart.Parser.ParseError);
+        expect(() => Bart.Parser.parse(error, context)).toThrow(Bart.Parser.ParseError);
     }
 });
 
@@ -273,7 +274,7 @@ test('Test match all combinator (empty string program)', () => {
     ];
 
     let context = new Bart.TabContext();
-    let ast = Bart.Parser.parse('');
+    let ast = Bart.Parser.parse('', context);
     let filter = ast.filter.filter();
 
     expect(tabs.filter(tab => filter(tab, context)).length).toBe(3);
@@ -314,3 +315,18 @@ test('Test $ (selected) tab filter', () => {
     expect(filteredTabs.length).toBe(1);
     expect(filteredTabs[0].id).toBe(2);
 });
+
+test('Test $windowId macro substition', () => {
+    let context = new Bart.TabContext();
+    context.currentWindowId = 123;
+
+    let tabs = [
+        new Bart.DummyTab('"xyz"', ' ', 123, 1),
+        new Bart.DummyTab('"rst"', ' ', 70, 2),
+    ]
+
+    let filteredTabs = Bart.Interpreter.interpret('windowId $windowId', tabs, context);
+
+    expect(filteredTabs.length).toBe(1);
+    expect(filteredTabs[0].windowId).toBe(123);
+})


### PR DESCRIPTION
If `$windowId` appears in a bart script, substitute it with a string containing the active browser window id. For example, `$windowId` is substituted with `"123"`. 

This change also includes a new filter, `windowId`. This filters all tabs that match the provided id: `windowId "123"`. This is still implemented as a string match this actually translates to `tab["windowId"].includes("123")`.

With these two changes there is now the equivalence `curr = windowId $windowId`.