### PR TITLE
Implement simple int arithmetic

### DIFF
--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -775,6 +775,10 @@ namespace Bart {
                 } else if (Lexer.isString(tokens[0].value)) {
                     combinator.strings.push(tokens[0].value);
                     tokens = tokens.slice(1);
+                } else if (Lexer.isInteger(tokens[0].value)) {
+                    // For now, cast to string
+                    combinator.strings.push(`"${tokens[0].value}"`);
+                    tokens = tokens.slice(1);
                 } else if (isStringCombinatorSequence(tokens)) {
                     let [childCombinator, remainder] = consumeStringCombinator(tokens);
                     tokens = remainder;

--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -860,6 +860,9 @@ namespace Bart {
 
             if (macro == '$windowId') {
                 substitution = `"${context.currentWindowId}"`;
+            } else if (macro == '$now') {
+                let now = Math.floor(Date.now()/1000);
+                return new Lexer.Token(0, 0, Lexer.TokenType.Integer, now+'');
             }
 
             return new Lexer.Token(0, 0, Lexer.TokenType.StringArg, substitution);

--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -863,6 +863,14 @@ namespace Bart {
             } else if (macro == '$now') {
                 let now = Math.floor(Date.now()/1000);
                 return new Lexer.Token(0, 0, Lexer.TokenType.Integer, now+'');
+            } else if (macro == '$1d') {
+                return new Lexer.Token(0, 0, Lexer.TokenType.Integer, (60*60*24)+'');
+            } else if (macro == '$1h') {
+                return new Lexer.Token(0, 0, Lexer.TokenType.Integer, (60*60)+'');
+            } else if (macro == '$1m') {
+                return new Lexer.Token(0, 0, Lexer.TokenType.Integer, 60+'');
+            } else if (macro == '$1s') {
+                return new Lexer.Token(0, 0, Lexer.TokenType.Integer, 1+'');
             }
 
             return new Lexer.Token(0, 0, Lexer.TokenType.StringArg, substitution);

--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -141,6 +141,9 @@ namespace Bart {
                     case TokenType.Integer:
                         bartClass = "bart-integer";
                         break;
+                    case TokenType.Arithmetic:
+                        bartClass = "bart-arithmetic";
+                        break;
                     case TokenType.Macro:
                         bartClass = "bart-macro";
                         break;
@@ -186,7 +189,8 @@ namespace Bart {
             Command,
             GroupModifier,
             Macro,
-            Integer
+            Integer,
+            Arithmetic
         }
 
         export function isGroupModifier(token: string): boolean {
@@ -195,6 +199,10 @@ namespace Bart {
 
         export function isString(token: string): boolean {
             return token.startsWith('"') && token.endsWith('"');
+        }
+
+        export function isArithmetic(token: string) {
+            return new Set([ '+', '-', '*', '/' ]).has(token);
         }
 
         export function isInteger(token: string): boolean {
@@ -303,6 +311,8 @@ namespace Bart {
                     tokens.push(new Bart.Lexer.Token(token.start, token.end, Bart.Lexer.TokenType.Macro, token.value));
                 } else if (Bart.Lexer.isInteger(token.value)) {
                     tokens.push(new Bart.Lexer.Token(token.start, token.end, Bart.Lexer.TokenType.Integer, token.value));
+                } else if (Bart.Lexer.isArithmetic(token.value)) {
+                    tokens.push(new Bart.Lexer.Token(token.start, token.end, Bart.Lexer.TokenType.Arithmetic, token.value));
                 } else {
                     tokens.push(new Bart.Lexer.Token(token.start, token.end, Bart.Lexer.TokenType.Invalid, token.value));
                     //throw new Parser.ParseError();

--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -138,6 +138,9 @@ namespace Bart {
                     case TokenType.GroupModifier:
                         bartClass = "bart-group-modifier";
                         break;
+                    case TokenType.Integer:
+                        bartClass = "bart-integer";
+                        break;
                     case TokenType.Macro:
                         bartClass = "bart-macro";
                         break;
@@ -182,7 +185,8 @@ namespace Bart {
             Combinator,
             Command,
             GroupModifier,
-            Macro
+            Macro,
+            Integer
         }
 
         export function isGroupModifier(token: string): boolean {
@@ -191,6 +195,10 @@ namespace Bart {
 
         export function isString(token: string): boolean {
             return token.startsWith('"') && token.endsWith('"');
+        }
+
+        export function isInteger(token: string): boolean {
+            return /^\d+$/.test(token);
         }
 
         export function isMacro(token: string): boolean {
@@ -293,6 +301,8 @@ namespace Bart {
                     tokens.push(new Bart.Lexer.Token(token.start, token.end, Bart.Lexer.TokenType.GroupModifier, token.value));
                 } else if (Bart.Lexer.isMacro(token.value)) {
                     tokens.push(new Bart.Lexer.Token(token.start, token.end, Bart.Lexer.TokenType.Macro, token.value));
+                } else if (Bart.Lexer.isInteger(token.value)) {
+                    tokens.push(new Bart.Lexer.Token(token.start, token.end, Bart.Lexer.TokenType.Integer, token.value));
                 } else {
                     tokens.push(new Bart.Lexer.Token(token.start, token.end, Bart.Lexer.TokenType.Invalid, token.value));
                     //throw new Parser.ParseError();

--- a/src/components/TabList.svelte
+++ b/src/components/TabList.svelte
@@ -577,7 +577,6 @@
         <div>
             <label for="bart-filter">Filter</label>
             <div id="bart-filter" on:click={focusFilter} tabindex="0"></div>
-            <button id="bart-execute-button" on:click={executeBartCommand}>Execute</button>
         </div>
         <div id="bart-prettyprint">
             <!-- {@html ast.print()} -->
@@ -605,6 +604,7 @@
         </div>
         
         <button on:click={closeSelectedTabs}>Close selected</button>
+        <button id="bart-execute-button" on:click={executeBartCommand}>Execute</button>
     </div>
     {#if ast.groupModifier.modifier == 'none'}
         {#each filteredTabs as tab (tab.id)}

--- a/src/components/TabList.svelte
+++ b/src/components/TabList.svelte
@@ -757,4 +757,8 @@
     :global(.bart-integer) {
         color: blue;
     }
+
+    :global(.bart-arithmetic) {
+        color: black;
+    }
 </style>

--- a/src/components/TabList.svelte
+++ b/src/components/TabList.svelte
@@ -707,7 +707,7 @@
     }
 
     #bart-filter {
-        width: 250px;
+        width: 400px;
         height: 20px;
         font-family: monospace;
         font-size: 16px;

--- a/src/components/TabList.svelte
+++ b/src/components/TabList.svelte
@@ -753,4 +753,8 @@
     :global(.bart-macro) {
         color: gray;
     }
+
+    :global(.bart-integer) {
+        color: blue;
+    }
 </style>


### PR DESCRIPTION
This MR implements integer args, integer arithmetic and several macros for use with the `timestamp` filter. Prefix integer arithmetic works as an argument to filters. For example: `timestamp - $now $1d` filters all tabs with timestamps occurring within the past 24 hours.

Newly supported arithmetic operators: `{+,-,*,/}`.

There is also a set of macros for performing date calculations with ease:

```
$now = current unix time
$1d = 1 day (in seconds)
$1h = 1 hour (in seconds)
$1m = 1 min (in seconds)
$1s = 1 sec (in seconds)
```