### PR TITLE
Implement 'uniq' filter

### DIFF
--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -24,6 +24,8 @@ namespace Bart {
         url: string
         windowId: number
         id: number
+
+        [field: string]: any;
     }
 
     export interface Storage {
@@ -561,13 +563,16 @@ namespace Bart {
                                 console.log('Building stateful filter');
                                 const prev = new Set();
                                 return async (tab: Tab, context: Context): Promise<boolean> => {
-                                    console.log('running uniq filter');
-                                    console.log('prev set: ' + prev);
-                                    if (prev.has(tab.id+'')) {
+                                    let field = 'id';
+                                    if (this.arg.strings.length > 0) {
+                                        field = this.arg.strings[0].slice(1,-1);
+                                    }
+
+                                    if (prev.has(tab[field]+'')) {
                                         return false;
                                     }
 
-                                    prev.add(tab.id+'');
+                                    prev.add(tab[field]+'');
                                     return true;
                                 }
                             }

--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -563,7 +563,7 @@ namespace Bart {
                                 console.log('Building stateful filter');
                                 const prev = new Set();
                                 return async (tab: Tab, context: Context): Promise<boolean> => {
-                                    let field = 'id';
+                                    let field = 'url';
                                     if (this.arg.strings.length > 0) {
                                         field = this.arg.strings[0].slice(1,-1);
                                     }

--- a/src/bart/util.ts
+++ b/src/bart/util.ts
@@ -1,0 +1,25 @@
+namespace Util {
+    // Return a factor that maintains state;
+    export function lazy() {
+        let cache = undefined;
+        return (target: any, propertyKey: string) => {
+            // TODO: Implement getter / setter of the prototype
+            // TODO: Init cache to initially assigned val
+            Object.defineProperty(target, propertyKey, {
+                get: () => {
+                    cache;
+                },
+                set: (newVal) => {
+                    cache = newVal;
+                }
+            });
+        };
+    }
+
+    export class TestClass {
+        @lazy()
+        example: string;
+    }
+}
+
+export { Util };

--- a/src/components/TabList.svelte
+++ b/src/components/TabList.svelte
@@ -275,6 +275,7 @@
 
         //filteredTabs = tabs.filter(async tab => await filter(tab, bartContext));
         // TODO: Async filter options? (Promise.all() etc?)
+        console.log("Filter tabs: %o", ast.filter);
         let displayedTabs = [];
         for (const tab of tabs) {
             if (await filter(tab, bartContext)) {
@@ -288,7 +289,7 @@
 
     // TODO: Handle parse error
     $: ast = (groupBySelection == 'none') ? parseAST(bartFilterInput) : parseAST(bartFilterInput).modifier(groupModifier);
-    $: console.dir(ast, { depth: null });
+    $: console.log("AST: %o", ast);
     $: {
         console.dir(ast, { depth: null })
         filterTabs();

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -9,9 +9,9 @@ test('lazy decorator test', () => {
 });
 */
 
-test('uniq test', async () => {
+test('uniq state test', async () => {
     let context = new Bart.TabContext();
-    let ast = Bart.Parser.parse('uniq', context);
+    let ast = Bart.Parser.parse('uniq "id"', context);
 
     let filter = ast.filter.filter();
     //console.log('Filter: ' + ast.filter.print());
@@ -26,7 +26,7 @@ test('uniq test', async () => {
     expect(await filter(tab2, context)).toBe(false);
 });
 
-test('uniq test specified field', async () => {
+test('uniq test url field', async () => {
     let context = new Bart.TabContext();
     let ast = Bart.Parser.parse('uniq "url"', context);
 

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -1,0 +1,27 @@
+import { Util } from 'src/bart/util';
+import { Bart } from 'src/bart/bart';
+
+/*
+test('lazy decorator test', () => {
+    let test = new Util.TestClass();
+
+    expect(test.example).toBe(undefined);
+});
+*/
+
+test('uniq test', async () => {
+    let context = new Bart.TabContext();
+    let ast = Bart.Parser.parse('uniq', context);
+
+    let filter = ast.filter.filter();
+    console.log('Filter: ' + ast.filter.print());
+    let tab1 = new Bart.DummyTab('title1', 'url1', 0, 0);
+    let tab2 = new Bart.DummyTab('title1', 'url1', 0, 1);
+
+    console.log(ast.filter.filters);
+    // Proof that state is preserved.
+    expect(await filter(tab1, context)).toBe(true);
+    expect(await filter(tab1, context)).toBe(false);
+    expect(await filter(tab2, context)).toBe(true);
+    expect(await filter(tab2, context)).toBe(false);
+});

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -14,14 +14,31 @@ test('uniq test', async () => {
     let ast = Bart.Parser.parse('uniq', context);
 
     let filter = ast.filter.filter();
-    console.log('Filter: ' + ast.filter.print());
+    //console.log('Filter: ' + ast.filter.print());
     let tab1 = new Bart.DummyTab('title1', 'url1', 0, 0);
     let tab2 = new Bart.DummyTab('title1', 'url1', 0, 1);
 
-    console.log(ast.filter.filters);
+    //console.log(ast.filter.filters);
     // Proof that state is preserved.
     expect(await filter(tab1, context)).toBe(true);
     expect(await filter(tab1, context)).toBe(false);
     expect(await filter(tab2, context)).toBe(true);
     expect(await filter(tab2, context)).toBe(false);
+});
+
+test('uniq test specified field', async () => {
+    let context = new Bart.TabContext();
+    let ast = Bart.Parser.parse('uniq "url"', context);
+
+    let filter = ast.filter.filter();
+    let tab1 = new Bart.DummyTab('title1', 'url1', 0, 0);
+    let tab2 = new Bart.DummyTab('title1', 'url1', 0, 1);
+    let tab3 = new Bart.DummyTab('title1', 'url2', 0, 1);
+
+    expect(tab1['url']).toBe('url1');
+
+    // Proof that state is preserved.
+    expect(await filter(tab1, context)).toBe(true);
+    expect(await filter(tab2, context)).toBe(false);
+    expect(await filter(tab3, context)).toBe(true);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,9 +12,11 @@
          * Note that setting allowJs false does not prevent the use
          * of JS in `.svelte` files.
          */
+        "experimentalDecorators": true,
         "allowJs": true,
         "checkJs": true,
         "isolatedModules": true,
+        "noFallthroughCasesInSwitch": true,
         "types": ["jest", "chrome"],
     },
     "include": [


### PR DESCRIPTION
This PR implements the `uniq` filter. It takes an optional string argument, the tab field, to perform the uniqueness check against. If no argument is provided this argument is implicitly `"url"`.

Therefore, `uniq` on its own will filter all tabs such that each url appears only once. The order of tab iteration is not well-defined; there are no guarantees as to which tab of a given url is kept.