### PR TITLE
Implement sort modifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+bart-chrome-debug/
+
 # Logs
 logs
 *.log

--- a/launch-chrome-macos-debug.sh
+++ b/launch-chrome-macos-debug.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' --remote-debugging-port=9797 --user-data-dir=./bart-chrome-debug/

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -9,9 +9,9 @@ chrome.action.onClicked.addListener((activeTab) => {
 })
 
 chrome.tabs.onCreated.addListener((tab) => {
-    console.log('Opened tab: ' + tab.id);
+    console.log('Opened tab: %o', tab);
 
-    let timestamp = parseInt(Date.now()/1000);
+    let timestamp = Math.floor(Date.now()/1000);
 
     let entry = {}
     entry[tab.id+''] = timestamp;

--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -850,7 +850,7 @@ namespace Bart {
             return Lexer.isCombinator(tokens[0].value) && Lexer.isFilter(tokens[1].value);
         }
 
-        export function consumeSortModifier(tokens: Lexer.Token[]): [remaining: Lexer.Token[], modifier: SortModifier] {
+        export function consumeSortModifier(tokens: Lexer.Token[], storage: Storage = new ChromeLocalStorage()): [remaining: Lexer.Token[], modifier: SortModifier] {
             if (Lexer.isSortModifier(tokens[0].value) == false) {
                 throw new ParseError();
             }
@@ -869,7 +869,7 @@ namespace Bart {
                 tokens = tokens.slice(1);
             }
 
-            return [tokens, new SortModifier(field, relation)];
+            return [tokens, new SortModifier(field, relation, storage)];
         }
 
         export function consumeGroupModifier(tokens: Lexer.Token[]): [remaining: Lexer.Token[], modifier: GroupModifier] {
@@ -1090,7 +1090,7 @@ namespace Bart {
             return tokens;
         }
 
-        export function parse(input: string, context: Context): Command {
+        export function parse(input: string, context: Context, storage: Storage = new ChromeLocalStorage()): Command {
             let command: Command = Command.noop();
             let commandSymbol = command.type;
             let commandArgs = StringCombinator.emptyCombinator;
@@ -1129,7 +1129,7 @@ namespace Bart {
                     console.log('Parsing group modifier');
                 } else if (tokens[0].value == 'sort') {
                     // TODO: Consume sort modifier
-                    [tokens, sortModifier] = consumeSortModifier(tokens);
+                    [tokens, sortModifier] = consumeSortModifier(tokens, storage);
                 } else {
                     break;
                 }

--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -427,11 +427,20 @@ namespace Bart {
 
                 if (this.field == 'timestamp') {
                     return async (a,b) => {
-                        let aTimestamp = await this.storage.get(a.id+'');
+                        let aTimestamp = (await this.storage.get(a.id+''));
                         let bTimestamp = await this.storage.get(b.id+'');
 
-                        aTimestamp = aTimestamp[a.id+''];
-                        bTimestamp = bTimestamp[b.id+''];
+                        if (aTimestamp) {
+                            aTimestamp = aTimestamp[a.id+''];
+                        } else {
+                            aTimestamp = 0;
+                        }
+
+                        if (bTimestamp) {
+                            bTimestamp = bTimestamp[b.id+''];
+                        } else {
+                            bTimestamp = 0;
+                        }
 
                         return relation(aTimestamp, bTimestamp);
                     }

--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -442,9 +442,9 @@ namespace Bart {
                 }
             }
 
-            async sort(tabs: Tab[], equator: Util.AsyncEquator<Tab> = Util.defaultEquator()): Promise<Tab[]> {
+            async sort(tabs: Tab[]): Promise<Tab[]> {
                 let comparator = this.buildComparator();
-                return await Util.asyncSort(tabs, comparator, equator);
+                return await Util.asyncSort(tabs, comparator);
             }
         }
 

--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -407,6 +407,13 @@ namespace Bart {
                 this.field = field;
                 this.relation = relation;
             }
+
+            // TODO: Needs context if interested in sorting on timestamp (better way?)
+            // Problem: must be async -- since reading tab timestamp is an async op
+            async comparator(a: Tab, b: Tab): Promise<boolean> {
+
+                return false;
+            }
         }
 
         export class GroupModifier {

--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -429,7 +429,7 @@ namespace Bart {
 
                 if (this.field == 'timestamp') {
                     return async (a,b) => {
-                        console.log('a: %o, b: %o', a, b);
+                        console.log('a: %o, b: %o, relation: %o', a, b, relation);
                         let aTimestamp = await this.storage.get(a.id+'');
                         let bTimestamp = await this.storage.get(b.id+'');
 
@@ -447,9 +447,9 @@ namespace Bart {
                 }
             }
 
-            async sort(tabs: Tab[]): Promise<Tab[]> {
+            async sort(tabs: Tab[], equator: Util.AsyncEquator<Tab> = Util.defaultEquator()): Promise<Tab[]> {
                 let comparator = this.buildComparator();
-                return await Util.asyncSort(tabs, comparator);
+                return await Util.asyncSort(tabs, comparator, equator);
             }
         }
 

--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -143,6 +143,9 @@ namespace Bart {
                     case TokenType.GroupModifier:
                         bartClass = "bart-group-modifier";
                         break;
+                    case TokenType.SortModifier:
+                        bartClass = "bart-sort-modifier"
+                        break;
                     case TokenType.Integer:
                         bartClass = "bart-integer";
                         break;
@@ -199,6 +202,7 @@ namespace Bart {
             Combinator,
             Command,
             GroupModifier,
+            SortModifier,
             Macro,
             Integer,
             Arithmetic,
@@ -335,6 +339,8 @@ namespace Bart {
                     tokens.push(new Bart.Lexer.Token(token.start, token.end, Bart.Lexer.TokenType.Command, token.value));
                 } else if (Bart.Lexer.isGroupModifier(token.value)) {
                     tokens.push(new Bart.Lexer.Token(token.start, token.end, Bart.Lexer.TokenType.GroupModifier, token.value));
+                } else if (Bart.Lexer.isSortModifier(token.value)) {
+                    tokens.push(new Bart.Lexer.Token(token.start, token.end, Bart.Lexer.TokenType.SortModifier, token.value));
                 } else if (Bart.Lexer.isMacro(token.value)) {
                     tokens.push(new Bart.Lexer.Token(token.start, token.end, Bart.Lexer.TokenType.Macro, token.value));
                 } else if (Bart.Lexer.isInteger(token.value)) {

--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -425,10 +425,18 @@ namespace Bart {
                     relation = (a,b) => a > b;
                 }
 
+                console.log('sort comparator: %o', this);
+
                 if (this.field == 'timestamp') {
                     return async (a,b) => {
-                        let aTimestamp = parseInt(await this.storage.get(a.id+''));
-                        let bTimestamp = parseInt(await this.storage.get(b.id+''));
+                        console.log('a: %o, b: %o', a, b);
+                        let aTimestamp = await this.storage.get(a.id+'');
+                        let bTimestamp = await this.storage.get(b.id+'');
+
+                        console.log('a ts: %o, b ts: %o', aTimestamp, bTimestamp);
+
+                        aTimestamp = aTimestamp[a.id+''];
+                        bTimestamp = bTimestamp[b.id+''];
 
                         return relation(aTimestamp, bTimestamp);
                     }

--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -425,15 +425,10 @@ namespace Bart {
                     relation = (a,b) => a > b;
                 }
 
-                console.log('sort comparator: %o', this);
-
                 if (this.field == 'timestamp') {
                     return async (a,b) => {
-                        console.log('a: %o, b: %o, relation: %o', a, b, relation);
                         let aTimestamp = await this.storage.get(a.id+'');
                         let bTimestamp = await this.storage.get(b.id+'');
-
-                        console.log('a ts: %o, b ts: %o', aTimestamp, bTimestamp);
 
                         aTimestamp = aTimestamp[a.id+''];
                         bTimestamp = bTimestamp[b.id+''];
@@ -732,11 +727,9 @@ namespace Bart {
                             childResult = await childFilter(tab, context);
                         }
 
-                        console.log('& Combinator filter computation');
                         if (this.combinator == '&') {
                             let promises: Promise<boolean>[] = filters.map(f => f(tab, context));
                             let results: boolean[] = await Promise.all(promises);
-                            console.log('results: %o', results);
                             return results.every(result => result) && childResult;
                         } else if (this.combinator == '|') {
                             return (await Promise.all(filters.map(f => f(tab, context)))).some(result => result) || childResult;

--- a/src/bart/util.ts
+++ b/src/bart/util.ts
@@ -41,11 +41,13 @@ namespace Util {
     }
 
     // TODO: Potential equality issues
-    export async function asyncArgMinimal<T>(arr: T[], comparator: AsyncComparator<T>, equator: AsyncEquator<T> = defaultEquator()): Promise<number> {
+    export async function asyncArgMinimal<T>(arr: T[], comparator: AsyncComparator<T>): Promise<number> {
         let minimal = await asyncMinimal(arr, comparator);
         for (let i = 0; i < arr.length; i++) {
-            let equal = await equator(minimal, arr[i]);
-            if (equal) {
+            // If the arg is minimal it will compare less than all other elements aside from itself.
+            // Note -- only works if the comparator does not contain equality.
+            let hitMin = (await comparator(minimal, arr[i]) == false);
+            if (hitMin) {
                 return i;
             }
         }
@@ -53,13 +55,13 @@ namespace Util {
 
     // Inefficient but pretty.
     // TODO: Allow equator? 
-    export async function asyncSort<T>(arr: T[], comparator: AsyncComparator<T>, equator: AsyncEquator<T> = defaultEquator()): Promise<T[]> {
+    export async function asyncSort<T>(arr: T[], comparator: AsyncComparator<T>): Promise<T[]> {
         if (arr.length <= 1) {
             return arr;
         }
 
-        let argMin = await asyncArgMinimal(arr, comparator, equator);
-        let sublist = await asyncSort([...arr.slice(0, argMin), ...arr.slice(argMin+1)], comparator, equator);
+        let argMin = await asyncArgMinimal(arr, comparator);
+        let sublist = await asyncSort([...arr.slice(0, argMin), ...arr.slice(argMin+1)], comparator);
         return [arr[argMin], ...sublist];
     }
 }

--- a/src/bart/util.ts
+++ b/src/bart/util.ts
@@ -20,6 +20,47 @@ namespace Util {
         @lazy()
         example: string;
     }
+
+
+    export type AsyncComparator<T> = (a:T, b:T) => Promise<Boolean>;
+    export type AsyncEquator<T> = (a:T, b:T) => Promise<Boolean>;
+
+    export function defaultEquator<T>(): AsyncEquator<T> {
+        return async (a,b) => a == b;
+    }
+
+    export async function asyncMinimal<T>(arr: T[], comparator: AsyncComparator<T>): Promise<T> {
+        // TODO: Handling of [] case?
+        if (arr.length == 1) {
+            return arr[0];
+        } else {
+            let e = arr[0];
+            let subMinimal = await asyncMinimal(arr.slice(1), comparator);
+            return (await comparator(e, subMinimal)) ? e : subMinimal;
+        }
+    }
+
+    // TODO: Potential equality issues
+    export async function asyncArgMinimal<T>(arr: T[], comparator: AsyncComparator<T>, equator: AsyncEquator<T> = defaultEquator()): Promise<number> {
+        let minimal = await asyncMinimal(arr, comparator);
+        for (let i = 0; i < arr.length; i++) {
+            let equal = await equator(minimal, arr[i]);
+            if (equal) {
+                return i;
+            }
+        }
+    }
+
+    // Inefficient but pretty.
+    // TODO: Allow equator? 
+    export async function asyncSort<T>(arr: T[], comparator: AsyncComparator<T>): Promise<T[]> {
+        if (arr.length <= 1) {
+            return arr;
+        }
+
+        let argMin = await asyncArgMinimal(arr, comparator);
+        return [arr[argMin], ...arr.slice(0, argMin), ...arr.slice(argMin+1)];
+    }
 }
 
 export { Util };

--- a/src/bart/util.ts
+++ b/src/bart/util.ts
@@ -53,13 +53,14 @@ namespace Util {
 
     // Inefficient but pretty.
     // TODO: Allow equator? 
-    export async function asyncSort<T>(arr: T[], comparator: AsyncComparator<T>): Promise<T[]> {
+    export async function asyncSort<T>(arr: T[], comparator: AsyncComparator<T>, equator: AsyncEquator<T> = defaultEquator()): Promise<T[]> {
         if (arr.length <= 1) {
             return arr;
         }
 
-        let argMin = await asyncArgMinimal(arr, comparator);
-        return [arr[argMin], ...arr.slice(0, argMin), ...arr.slice(argMin+1)];
+        let argMin = await asyncArgMinimal(arr, comparator, equator);
+        let sublist = await asyncSort([...arr.slice(0, argMin), ...arr.slice(argMin+1)], comparator, equator);
+        return [arr[argMin], ...sublist];
     }
 }
 

--- a/src/components/TabList.svelte
+++ b/src/components/TabList.svelte
@@ -778,6 +778,10 @@
         color: blue;
     }
 
+    :global(.bart-sort-modifier) {
+        color: blue;
+    }
+
     :global(.bart-macro) {
         color: gray;
     }

--- a/src/components/TabList.svelte
+++ b/src/components/TabList.svelte
@@ -283,7 +283,15 @@
             }
         }
 
-        filteredTabs = displayedTabs;
+        if (ast.sortModifier) {
+            // TODO: Better to stick with chrome's provided tab interface.
+            console.log('sorting tabs');
+            filteredTabs = await ast.sortModifier.sort(displayedTabs);
+        } else {
+            console.log('not sorting tabs');
+            filteredTabs = displayedTabs;
+        }
+        console.log('Filtered tabs: %o', filteredTabs);
         console.log('Filter count: ' + displayedTabs.length);
     }
 

--- a/tests/bart.test.ts
+++ b/tests/bart.test.ts
@@ -2,6 +2,7 @@ import { Bart } from 'src/bart/bart';
 
 export {};
 
+/*
 test('Test tokenization of input', () => {
     let results = Bart.Lexer.tokenize('"abc 123"  "xyz"    999  777');
     expect(results).toEqual(['"abc 123"', '"xyz"', '999', '777']);
@@ -330,3 +331,30 @@ test('Test $windowId macro substition', () => {
     expect(filteredTabs.length).toBe(1);
     expect(filteredTabs[0].windowId).toBe(123);
 })
+*/
+
+test('Test sort modifier', () => {
+    let context = new Bart.TabContext();
+    let ast = Bart.Parser.parse('sort', context);
+
+    expect(ast.sortModifier.field).toBe('timestamp');
+
+    ast = Bart.Parser.parse('sort ">"', context);
+    expect(ast.sortModifier.relation).toBe('>');
+
+    ast = Bart.Parser.parse('sort ">" "url"', context);
+    expect(ast.sortModifier.relation).toBe('>');
+    expect(ast.sortModifier.field).toBe('url');
+});
+
+test('Test explicit group modifier and sort modifier', () => {
+    let context = new Bart.TabContext();
+    let ast = Bart.Parser.parse('sort group "window"', context);
+
+    expect(ast.sortModifier.field).toBe('timestamp');
+    expect(ast.groupModifier.modifier).toBe('window');
+
+    ast = Bart.Parser.parse('group "window" sort', context);
+    expect(ast.sortModifier.field).toBe('timestamp');
+    expect(ast.groupModifier.modifier).toBe('window');
+});

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -65,6 +65,7 @@ test('[Util] Test SortModifier timestamp sort', async () => {
         }
     }
 
+    let context = new Bart.TabContext();
     let storage = new DummyStorage();
     let modifier = new Bart.Parser.SortModifier('timestamp', '<', storage);
 
@@ -83,6 +84,20 @@ test('[Util] Test SortModifier timestamp sort', async () => {
 
     expect(results[0].id).toBe(1);
     expect(results[2].id).toBe(3);
+
+    modifier.relation = '>';
+    results = await modifier.sort(tabs);
+
+    expect(results[0].id).toBe(3);
+    expect(results[2].id).toBe(1);
+
+    let program = Bart.Parser.parse('sort ">" "timestamp"', context, storage);
+
+    // There should be identical results from the program itself
+    results = await program.sortModifier.sort(tabs);
+
+    expect(results[0].id).toBe(3);
+    expect(results[2].id).toBe(1);
 });
 
 test('uniq state test', async () => {

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -85,14 +85,7 @@ test('[Util] Test SortModifier timestamp sort', async () => {
         new Bart.DummyTab('', '', 0, 1),
     ];
 
-    let timestampEquator = async (tab1, tab2) => {
-        let ts1 = await storage.get(tab1.id+'');
-        let ts2 = await storage.get(tab2.id+'');
-
-        return ts1[tab1.id+''] == ts2[tab2.id+''];
-    };
-
-    let results = await modifier.sort(tabs, timestampEquator);
+    let results = await modifier.sort(tabs);
 
     expect(results[0].id).toBe(1);
     expect(results[2].id).toBe(3);

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -9,6 +9,36 @@ test('lazy decorator test', () => {
 });
 */
 
+test('[Util] Test async minimal', async () => {
+    let arr = [1,4,2,5];
+    let comparator: Util.AsyncComparator<number> = async (a,b) => {
+        return a < b;
+    };
+
+    let result = await Util.asyncMinimal(arr, comparator);
+    expect(result).toBe(1);
+});
+
+test('[Util] Test async arg minimal', async () => {
+    let arr = [1,1,1,3,0,5];
+    let comparator: Util.AsyncComparator<number> = async (a,b) => {
+        return a < b;
+    };
+
+    let result = await Util.asyncArgMinimal(arr, comparator);
+    expect(result).toBe(4);
+});
+
+test('[Util] Test async sort', async () => {
+    let arr = [1,1,1,3,0,5];
+    let comparator: Util.AsyncComparator<number> = async (a,b) => {
+        return a < b;
+    };
+
+    let result = await Util.asyncSort(arr, comparator);
+    expect(result).toStrictEqual([0,1,1,1,3,5]);
+});
+
 test('uniq state test', async () => {
     let context = new Bart.TabContext();
     let ast = Bart.Parser.parse('uniq "id"', context);

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -39,6 +39,52 @@ test('[Util] Test async sort', async () => {
     expect(result).toStrictEqual([0,1,1,1,3,5]);
 });
 
+test('[Util] Test SortModifier timestamp sort', async () => {
+    // TODO: Add to mocks / tests top-level for import?
+    class DummyStorage implements Bart.Storage {
+        keys: { [key: string]: any };
+
+        constructor() {
+            this.keys = {};
+        }
+
+        get(key: string): Promise<any> {
+            return this.keys[key];
+        }
+
+        set(items: { [key: string]: any; }): Promise<void> {
+            for (const [key,_] of Object.entries(items)) {
+                this.keys[key] = items[key];
+            }
+
+            return;
+        }
+
+        erase(): Promise<void> {
+            return;
+        }
+    }
+
+    let storage = new DummyStorage();
+    let modifier = new Bart.Parser.SortModifier('timestamp', '<', storage);
+
+    // Tab ids, timestamp
+    await storage.set({'1': '100'})
+    await storage.set({'2': '200'})
+    await storage.set({'3': '1000'})
+
+    let tabs: Bart.DummyTab[] = [
+        new Bart.DummyTab('', '', 0, 2),
+        new Bart.DummyTab('', '', 0, 3),
+        new Bart.DummyTab('', '', 0, 1),
+    ];
+
+    let results = await modifier.sort(tabs);
+
+    expect(results[0].id).toBe(1);
+    expect(results[2].id).toBe(3);
+});
+
 test('uniq state test', async () => {
     let context = new Bart.TabContext();
     let ast = Bart.Parser.parse('uniq "id"', context);


### PR DESCRIPTION
This PR implements the `sort` modifier. This modifier has three forms:

- `sort`: implicitly, `sort "<" "timestamp"`; sorts the filter results such that the oldest occur first.
- `sort ">"`: implicitly, `sort ">" "timestamp"`; sorts the filter results such that the newest occur first.
- `sort "<" "url"`: sort filter results such that the shortest lexicographically appear first.