### PR TITLE
Filter shorthand changes

### DIFF
--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -261,7 +261,7 @@ namespace Bart {
                 'curr', '.',
                 '$', 
                 'windowId', 'w',
-                'since', 's',
+                'since', ':',
                 'uniq', '%' 
             ].includes(token);
         }
@@ -654,7 +654,7 @@ namespace Bart {
                     { names: ['url', 'u'], type: FilterType.Url },
                     { names: ['curr', '.'], type: FilterType.Curr },
                     { names: ['windowId', 'wId'], type: FilterType.WindowId },
-                    { names: ['since', 's'], type: FilterType.Since },
+                    { names: ['since', ':'], type: FilterType.Since },
                     { names: ['uniq', '%'], type: FilterType.Uniq },
                     { names: ['$'], type: FilterType.Selected }
                 ];

--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -258,7 +258,7 @@ namespace Bart {
             return [ 
                 'title', 't',
                 'url', 'u',
-                'curr', 'c',
+                'curr', '.',
                 '$', 
                 'windowId', 'w',
                 'since', 's',
@@ -275,7 +275,7 @@ namespace Bart {
         }
 
         export function isCommand(token: string): boolean {
-            return ['.', 'bm', 'move'].includes(token);
+            return ['bm', 'move'].includes(token);
         }
 
         export function tokenize(input: string): RawToken[] {
@@ -652,7 +652,7 @@ namespace Bart {
                 let nameMap = [
                     { names: ['title', 't'], type: FilterType.Title },
                     { names: ['url', 'u'], type: FilterType.Url },
-                    { names: ['curr', 'c'], type: FilterType.Curr },
+                    { names: ['curr', '.'], type: FilterType.Curr },
                     { names: ['windowId', 'wId'], type: FilterType.WindowId },
                     { names: ['since', 's'], type: FilterType.Since },
                     { names: ['uniq', '%'], type: FilterType.Uniq },

--- a/src/bart/bart.ts
+++ b/src/bart/bart.ts
@@ -861,7 +861,7 @@ namespace Bart {
             // TODO: Filter the tabs here instead..? And then return them?
             async execute(filteredTabs: Tab[]) {
                 switch (this.type) {
-                    case '.':
+                    case '':
                         // Do nothing.
                         console.log('noop, moving along.')
                         break;
@@ -884,7 +884,7 @@ namespace Bart {
 
             static noop(browser: Browser = new Browser()): Command {
                 let filter = new MatchAllFilterCombinator();
-                return new Command('.', StringCombinator.emptyCombinator, filter, GroupModifier.none, undefined, browser);
+                return new Command('', StringCombinator.emptyCombinator, filter, GroupModifier.none, undefined, browser);
             }
 
             modifier(mod: GroupModifier): Command {


### PR DESCRIPTION
`since` now has a shorthand of `:`.
`curr` now has a shorthand of `.`.

This also eliminates the no-op command `.`.