### PR TITLE
Improve tab selection debounce

### DIFF
--- a/src/bart/util.ts
+++ b/src/bart/util.ts
@@ -77,6 +77,50 @@ namespace Util {
 
         return results;
     }
+
+    export class DebounceScheduler {
+        private events: Map<string, DebounceScheduler.Event> = new Map();
+        static instance: DebounceScheduler = new DebounceScheduler();
+
+        private static loop() {
+            let scheduler = DebounceScheduler.instance;
+            let now = Date.now();
+            let entries = Array.from(scheduler.events.entries());
+
+            for (const [key,event] of entries) {
+                if (now >= event.execTime) {
+                    event.callback();
+                    scheduler.events.delete(key);
+                }
+            }
+        }
+
+        private constructor() {
+            setInterval(DebounceScheduler.loop, 20);
+        }
+
+        submit(key: string, debounce: number, callback: DebounceScheduler.Callback) {
+            this.events.set(key, new DebounceScheduler.Event(debounce, callback));
+        }
+    }
+
+    export namespace DebounceScheduler {
+        export type Callback = () => void;
+
+        export class Event {
+            execTime: number;
+            callback: Callback;
+
+            constructor(debounce: number, callback: Callback) {
+                this.execTime = Date.now() + debounce;
+                this.callback = callback;
+            }
+        }
+    }
+
+    
+
+    
 }
 
 export { Util };

--- a/src/components/TabList.svelte
+++ b/src/components/TabList.svelte
@@ -7,6 +7,7 @@
     import { Menu } from "./menu";
     import { writable } from "svelte/store";
     import SelectionRectangle from "./SelectionRectangle.svelte";
+    import { Util } from  "src/bart/util";
 
     type Tab = chrome.tabs.Tab;
     type Window = chrome.windows.Window;
@@ -19,6 +20,8 @@
     let hoveredTab: Tab = undefined;
     let bartFilterInput = '';
     let inputCursorPosition = 0;
+
+    let debounceScheduler = Util.DebounceScheduler.instance;
 
     // TODO: A better default?
     let groupBySelection = "none";

--- a/src/components/TabList.svelte
+++ b/src/components/TabList.svelte
@@ -43,6 +43,10 @@
     // The opposite (x,y) corner of the selection rectangle -- current (or final) mouse location.
     let tabSelectEndCoord: [x: number, y: number] = undefined;
 
+    enum DebounceTaskIdentifier {
+        tabSelect = "tabSelect"
+    };
+
     $: cursorStyle = (() => { 
         if (tabSelectStartCoord) {
             return "cursor: crosshair;"
@@ -58,14 +62,6 @@
 
     // TODO: Update in window mouse events
     let mouseState: [left: MouseButtonState, right: MouseButtonState] = [MouseButtonState.down, MouseButtonState.down];
-
-    function debounce(debounceTime: number, guard: () => boolean, action: () => void) {
-        setTimeout(() => {
-            if (guard()) {
-                action();
-            }
-        }, debounceTime);
-    }
 
     // TODO: Find approach that still supports typechecking
     DOMRect.prototype['overlap'] = function (rect: DOMRect): boolean {
@@ -161,8 +157,10 @@
         }
 
         console.log('mouse down event');
-        debounce(300, () => { return mouseState[0] == MouseButtonState.down }, () => {
-            tabSelectStartCoord = [event.clientX, event.clientY];
+        debounceScheduler.submit(DebounceTaskIdentifier.tabSelect, 300, () => {
+            if (mouseState[0] == MouseButtonState.down) {
+                tabSelectStartCoord = [event.clientX, event.clientY];
+            }
         });
     }
 


### PR DESCRIPTION
This PR implements a debounce task scheduler. If the same event occurs within the debounce window it is rescheduled to `now + debounce`. The scheduler replaces the old debounce code that often misbehaved if multiple events occurred within a quick succession.